### PR TITLE
feat(ci): add GitHub Actions workflow for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*" # Trigger on version tags
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Create zip file
+        run: |
+          cd out
+          zip -r ../signing-tool-private-key.zip .
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: signing-tool-private-key.zip
+          repository: HorizenOfficial/signing-tool-private-key
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Jira ticket: [[WEB3-1487] Signing Tool: Include Static Build in GitHub Releases](https://horizenlabs.atlassian.net/browse/WEB3-1487)

Add automated release workflow using GitHub Actions

## Changes
- Added new GitHub Actions workflow file (.github/workflows/release.yml)
- Configured workflow to trigger on version tag pushes
- Set up Node.js environment with npm caching
- Added build and release steps

## Features
- Automated release creation when pushing version tags
- Automatic upload of built files from out/ directory as release assets
- Uses official GitHub Actions for reliability and security

Example of release generated automatically: https://github.com/HorizenOfficial/signing-tool-private-key/releases/tag/v0.0.1-test 