### PR TITLE
chore(deps): update base-x to v5.0.1 and zencashjs base-x to v3.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1969,9 +1969,10 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base-x": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -6577,9 +6578,10 @@
       }
     },
     "node_modules/zencashjs/node_modules/base-x": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }


### PR DESCRIPTION
Jira ticket: [[WEB3-1504] [Audit] Fix npm vulnerability on signing-tool-private-key](https://horizenlabs.atlassian.net/browse/WEB3-1504)

This PR addresses a high severity vulnerability (CVE-2025-27611) in the base-x package that was disclosed last week. 

## Changes
- Updated base-x from v5.0.0 to v5.0.1
- Updated zencashjs dependency base-x from v3.0.10 to v3.0.11

## Features
- Enhanced security against homograph attacks
- Improved input validation for address encoding/decoding
- Maintained backward compatibility with existing functionality

Reference: [GHSA-xq7p-g2vc-g82p](https://github.com/advisories/GHSA-xq7p-g2vc-g82p)