### PR TITLE
refactor(testnet): update testnet claim message prefix to tZENCLAIM

### DIFF
--- a/app/components/organisms/SigningToolWithPrivateKey.tsx
+++ b/app/components/organisms/SigningToolWithPrivateKey.tsx
@@ -40,7 +40,7 @@ function SigningToolWithPrivateKey() {
   const form = useSigningForm();
 
   const { destinationAddress, privateKey, compressed, testnet } = form.watch();
-  const MESSAGE_TO_SIGN = "ZT3CLAIM" + destinationAddress;
+  const MESSAGE_TO_SIGN = "tZENCLAIM" + destinationAddress;
 
   useEffect(() => {
     const isPrivateKeyWif = isPrivateKeyOnWifFormat(privateKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signing-tool-private-key",
-  "version": "1.0.0-ZT3CLAIM",
+  "version": "1.0.0-tZENCLAIM",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signing-tool-private-key",
-      "version": "1.0.0-ZT3CLAIM",
+      "version": "1.0.0-tZENCLAIM",
       "dependencies": {
         "@hookform/resolvers": "3.10.0",
         "@radix-ui/react-dialog": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signing-tool-private-key",
-  "version": "1.0.0-ZT3CLAIM",
+  "version": "1.0.0-tZENCLAIM",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Update Claim Message Prefix to tZENCLAIM

Updates the message prefix used for signing operations from ZT3CLAIM to tZENCLAIM to align with the new testnet prefix format.

## Changes

- Modified message prefix in SigningToolWithPrivateKey.tsx from "ZT3CLAIM" to "tZENCLAIM"
- Updated version string in package.json and package-lock.json to reflect new prefix
- Ensures consistent prefix usage across the application